### PR TITLE
Add kaldi style text normalization

### DIFF
--- a/lhotse/bin/modes/recipes/ami.py
+++ b/lhotse/bin/modes/recipes/ami.py
@@ -32,8 +32,9 @@ __all__ = ["ami"]
 )
 @click.option(
     "--normalize-text",
-    is_flag=True,
-    help="If set, convert all text annotations to upper case (similar to Kaldi)",
+    type=click.Choice(["none", "upper", "kaldi"], case_sensitive=False),
+    default="kaldi",
+    help="Type of text normalization to apply (kaldi style, by default)",
 )
 def ami(
     corpus_dir: Pathlike,


### PR DESCRIPTION
This is to make the transcripts more similar to Kaldi data preparation, so that the WERs are more comparable. Note that the segments are still split differently (this recipe creates 1 segment per annotation provided in the xml, whereas Kaldi does further splitting based on punctuation marks) so WERs are not directly comparable.